### PR TITLE
Update esp-idf version to 5.0.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ default_envs = esp32-c3
 
 ; Common options for all the environments
 [env]
-platform = espressif32 @6.1.0 # Make sure it uses esp-idf = 5.0.1
+platform = espressif32 @6.3.2 # Make sure it uses esp-idf = 5.0.2
 monitor_speed = 115200
 monitor_echo = true
 monitor_eol = LF


### PR DESCRIPTION
Using espressif32 @6.1.0 (esp-idf 5.0.1) can cause problems when building the project, possibly linked to a wrong python package version.
This is also documented here https://community.platformio.org/t/esp-idf-pyparsing-expecting-end-of-text/23562/10

The solution suggested is to upgrade to [espressif32 @6.3.2 (esp-idf 5.0.2)](https://github.com/platformio/platform-espressif32/releases/tag/v6.3.2), which has been tested and works.

esp-idf 5.0.2 doesn't introduce any breaking changes from 5.0.1.